### PR TITLE
fixed warning to add requiresMainQueueSetup function

### DIFF
--- a/RNProximity/RNProximity/RNProximity.m
+++ b/RNProximity/RNProximity/RNProximity.m
@@ -12,6 +12,11 @@
 
 @synthesize bridge = _bridge;
 
++ (BOOL) requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (instancetype)init
 {
     if ((self = [super init])) {


### PR DESCRIPTION
Thanks to make great library.

when I implemented your library, I got warning like below.

![img_0205](https://user-images.githubusercontent.com/42969906/52322378-4cf3ae80-2a1c-11e9-990a-b1ffcc161c5a.jpg)

so I just added below code.

```
+ (BOOL) requiresMainQueueSetup
{
    return YES;
}
```