### PR TITLE
fix to restore functionality in later versions of react native

### DIFF
--- a/RNProximity/RNProximity/RNProximity.m
+++ b/RNProximity/RNProximity/RNProximity.m
@@ -37,7 +37,9 @@
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(proximityEnabled:(BOOL)enabled) {
+    dispatch_async(dispatch_get_main_queue(), ^{
   [[UIDevice currentDevice] setProximityMonitoringEnabled:enabled];
+    });
 }
 
 @end


### PR DESCRIPTION
iOS was crashing on initiating the app a few version updates ago. I've been using this fix to manually make my app work, but figured I might as well see if I can merge in a PR to help fix this for everyone else!